### PR TITLE
Add function to merge two indexes into one

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -72,6 +72,34 @@ func TestUnique(t *testing.T) {
 	}
 }
 
+func TestMerge(t *testing.T) {
+	a := NewMemOnlyIndex(nil)
+	b := NewMemOnlyIndex(nil)
+	listA := []*ExampleCity{
+		{ID: 0, Names: []string{"Amsterdam", "Amsterdam"}, Country: "NL"},
+		{ID: 2, Names: []string{"Sofia", "Sofia"}, Country: "BG"},
+	}
+	listB := []*ExampleCity{
+		{Names: []string{"Reykjavik", "Reykjavik"}, Country: "IS"},
+		{Names: []string{"Amsterdam", "Amsterdam"}, Country: "NL"},
+	}
+
+	a.Index(toDocuments(listA)...)
+	b.Index(toDocuments(listB)...)
+	a.MergeInto(b)
+
+	n := 0
+	q := iq.Or(a.Terms("names", "Amsterdam")...)
+
+	a.Foreach(q, func(did int32, score float32, doc Document) {
+		n++
+
+	})
+	if n != 2 {
+		t.Fatalf("expected 2 got %d", n)
+	}
+}
+
 func TestDelete(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	for k := 0; k < 100; k++ {

--- a/mem.go
+++ b/mem.go
@@ -30,28 +30,28 @@ func NewMemOnlyIndex(perField map[string]*analyzer.Analyzer) *MemOnlyIndex {
 	return m
 }
 
-func (a *MemOnlyIndex) MergeInto(b *MemOnlyIndex) {
-	offset := int32(len(a.forward))
+func (m *MemOnlyIndex) MergeInto(b *MemOnlyIndex) {
+	offset := int32(len(m.forward))
 
 	for k, v := range b.perField {
-		a.perField[k] = v
+		m.perField[k] = v
 	}
 
 	for field, terms := range b.postings {
 		for term, ps := range terms {
-			as := a.postings[field][term]
+			ms := m.postings[field][term]
 			for _, docId := range ps {
-				as = append(as, docId+offset)
+				ms = append(ms, docId+offset)
 			}
-			a.postings[field][term] = as
+			m.postings[field][term] = ms
 		}
 	}
 
 	for uuid, docId := range b.forwardByID {
-		a.forwardByID[uuid] = docId + offset
+		m.forwardByID[uuid] = docId + offset
 	}
 
-	a.forward = append(a.forward, b.forward...)
+	m.forward = append(m.forward, b.forward...)
 }
 
 func (m *MemOnlyIndex) Get(id int32) Document {

--- a/mem.go
+++ b/mem.go
@@ -31,6 +31,12 @@ func NewMemOnlyIndex(perField map[string]*analyzer.Analyzer) *MemOnlyIndex {
 }
 
 func (m *MemOnlyIndex) MergeInto(b *MemOnlyIndex) {
+	m.Lock()
+	defer m.Unlock()
+
+	b.RLock()
+	defer b.RUnlock()
+
 	offset := int32(len(m.forward))
 
 	for k, v := range b.perField {


### PR DESCRIPTION
This enables a simple implementation of parallel indexing. A set of
documents can be split into groups that are individually indexed and
then merged into a single index.